### PR TITLE
Fix Supabase env variable reference

### DIFF
--- a/utils/supabase/context.tsx
+++ b/utils/supabase/context.tsx
@@ -13,7 +13,7 @@ export function SupabaseProvider({ children }: { children: ReactNode }) {
     const supabase = useMemo(() => {
         return createClient<Database>(
             process.env.NEXT_PUBLIC_SUPABASE_URL!,
-            process.env.NEXT_PUBLIC_SUPABASE_KEY!,
+            process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
             {
                 global: {
                     fetch: async (url, options = {}) => {

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -8,7 +8,7 @@ export async function createClerkSupabaseClientSsr() {
 
     return createClient<Database>(
         process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_KEY!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
         {
             global: {
                 // Get the custom Supabase token from Clerk


### PR DESCRIPTION
## Summary
- use correct env var `NEXT_PUBLIC_SUPABASE_ANON_KEY`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684247a7d5b08320be75c219e0100ed0