### PR TITLE
Fix stripe key startup crash

### DIFF
--- a/app/api/create-payment-intent/route.ts
+++ b/app/api/create-payment-intent/route.ts
@@ -6,14 +6,15 @@ const SUPPORTED_CURRENCIES = [
   'USD','AED','AFN','ALL','AMD','ANG','AOA','ARS','AUD','AWG','AZN','BAM','BBD','BDT','BGN','BIF','BMD','BND','BOB','BRL','BSD','BWP','BYN','BZD','CAD','CDF','CHF','CLP','CNY','COP','CRC','CVE','CZK','DJF','DKK','DOP','DZD','EGP','ETB','EUR','FJD','FKP','GBP','GEL','GIP','GMD','GNF','GTQ','GYD','HKD','HNL','HTG','HUF','IDR','ILS','INR','ISK','JMD','JPY','KES','KGS','KHR','KMF','KRW','KYD','KZT','LAK','LBP','LKR','LRD','LSL','MAD','MDL','MGA','MKD','MMK','MNT','MOP','MUR','MVR','MWK','MXN','MYR','MZN','NAD','NGN','NIO','NOK','NPR','NZD','PAB','PEN','PGK','PHP','PKR','PLN','PYG','QAR','RON','RSD','RUB','RWF','SAR','SBD','SCR','SEK','SGD','SHP','SLE','SOS','SRD','STD','SZL','THB','TJS','TOP','TRY','TTD','TWD','TZS','UAH','UGX','UYU','UZS','VND','VUV','WST','XAF','XCD','XCG','XOF','XPF','YER','ZAR','ZMW'
 ];
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
-if (!stripeSecretKey) {
-  throw new Error('STRIPE_SECRET_KEY environment variable is required');
-}
-const stripe = new Stripe(stripeSecretKey, { apiVersion: '2024-04-10' });
-
 export async function POST(req: NextRequest) {
   try {
+    // Move Stripe key check and initialization here
+    const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+    if (!stripeSecretKey) {
+      return NextResponse.json({ error: 'STRIPE_SECRET_KEY environment variable is required' }, { status: 500 });
+    }
+    const stripe = new Stripe(stripeSecretKey, { apiVersion: '2024-04-10' });
+
     const { amount, currency } = await req.json();
     // Validate amount
     if (


### PR DESCRIPTION
Move `STRIPE_SECRET_KEY` check and Stripe client initialization into the POST function to prevent application crashes at startup.

The previous module-level check caused the Next.js application to crash if the `STRIPE_SECRET_KEY` was missing, preventing the app from running even when Stripe functionality was not in use. Moving the check allows for graceful error handling per request.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-92bc4ecf-89c9-49fb-949c-f36aa343f215) · [Cursor](https://cursor.com/background-agent?bcId=bc-92bc4ecf-89c9-49fb-949c-f36aa343f215)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)